### PR TITLE
update libsecp256k1 to v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ethereum-types = "0.4"
 hashbrown = { version = "0.3", features = ["rayon"] }
 hasher = { version="0.1" }
 hex = "0.3"
-libsecp256k1 = "0.2"
+secp256k1 = { package = "libsecp256k1", version = "0.6" }
 log = "0.4"
 ripemd160 = "0.8"
 rlp = "0.3"

--- a/src/native.rs
+++ b/src/native.rs
@@ -72,7 +72,7 @@ fn is_signature_valid(r: &H256, s: &H256, v: u8) -> bool {
 
 /// Recover public from signed messages.
 fn recover(input: &[u8], hash: &[u8], bit: u8) -> Result<H512, secp256k1::Error> {
-    let signature = secp256k1::Signature::parse_slice(&input[64..128])?;
+    let signature = secp256k1::Signature::parse_standard_slice(&input[64..128])?;
     let message = secp256k1::Message::parse_slice(&hash[..])?;
     let recovery_id = secp256k1::RecoveryId::parse(bit)?;
     let pub_key = secp256k1::recover(&message, &signature, &recovery_id)?;


### PR DESCRIPTION
```
error: failed to select a version for the requirement `hmac = "^0.4"`
candidate versions found which didn't match: 0.11.0, 0.10.1, 0.10.0, ...
location searched: crates.io index
required by package `hmac-drbg v0.1.0`
    ... which is depended on by `libsecp256k1 v0.2.0`
    ... which is depended on by `cita-vm v0.2.1`
```
`libsecp256k1 v0.2` -> `hmac-drbg v0.1.0` -> `hmac v0.4`(recently yanked)

This pr fixes this by updating `libsecp256k1`'s version to `0.6`.
It compiles but I didn't test its functionality.