### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Cryptape Technologies <contact@cryptape.com>"]
 edition = "2021"
 description = "CITA VM"
 license = "Apache-2.0"
-homepage = "https://github.com/cryptape/cita-vm"
+repository = "https://github.com/cryptape/cita-vm"
 documentation = "https://github.com/cryptape/cita-vm/blob/master/README.md"
 
 [dependencies]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).